### PR TITLE
total overhaul supporting marshalling types!

### DIFF
--- a/Content/Mods/StyxScribeShared/StyxScribeShared.lua
+++ b/Content/Mods/StyxScribeShared/StyxScribeShared.lua
@@ -1,58 +1,276 @@
 ModUtil.Mod.Register( "StyxScribeShared" )
 
+local delim = '¦'
 local registry
 local lookup
 local objectData
 local encode
 local decode
-local new
+local ready
+local marshall
+local classes = { }
+local marshallTypes = { }
+local marshallTypesOrder = { }
 
-local meta = {
-	__call = function( )
-		return new( )
-	end,
-	__newindex = function( s, k, v )
-		local I = tostring( lookup[ s ] )
-		local K = encode( k )
-		local V = encode( v )
-		objectData[ s ][ k ] = v
-		print( "StyxScribeShared: Set: " .. I .. '¦' .. K .. '¦' .. V )
-	end,
-	__index = function( s, k )
-		return objectData[ s ][ k ]
-	end,
-	__len = function( s )
-		return #objectData[ s ]
-	end,
-	__next = function( s, ... )
-		return next( objectData[ s ], ... )
-	end,
-	__inext = function( s, ... )
-		return inext( objectData[ s ], ... )
-	end,
-	__pairs = function( s, ... )
-		return pairs( objectData[ s ], ... )
-	end,
-	__ipairs = function( s, ... )
-		return ipairs( objectData[ s ], ... )
+local function nop( ... ) return ... end
+
+local function typeCall( m, f )
+	local mm = getmetatable( m ) or { }
+	mm.__call = f
+	return setmetatable( m, mm )
+end
+
+local function marshallType( ... )
+	local types = { ... }
+	local m = table.remove( types )
+	table.insert( marshallTypesOrder, m )
+	for _, t in ipairs( types ) do
+		mt = marshallTypes[ m ] or { }
+		table.insert( mt, t )
+		marshallTypes[ m ] = mt
+	end
+	return m
+end
+
+-- mirror the structure of the python classes as metatables (mostly)
+local function class( name, ... )
+	local metas = table.pack( ... )
+	local n = metas.n
+	local m = metas[ n ]
+	for i = n - 1, 1, -1 do
+		metas[ i + 1 ] = metas[ i ]
+	end
+	metas[ 1 ] = m
+	local meta = { }
+	for i = n, 1, -1 do
+		for k, v in pairs( metas[ i ] ) do
+			meta[ k ] = v
+		end
+	end
+	if name ~= nil then
+		meta._name = name
+		classes[ name ] = meta
+	end
+	meta._parents = { table.unpack( metas, 2, n ) }
+	return meta
+end
+
+local function new( m, ... )
+	return m:_new( ... )
+end
+
+local _table = {
+	_new = function( )
+		return { }
 	end
 }
 
-function new( id )
-	local s = setmetatable( { }, meta )
-	id = id or tonumber( ModUtil.ToString.Address( s ), 16 )
-	objectData[ s ] = { }
-	registry[ id ] = s
-	lookup[ s ] = id
-	if id > 0 then
-		print( "StyxScribeShared: New: " .. id )
+local _function = {
+	_new = function( )
+		return nop
 	end
-	return s
-end
+}
 
-local function handleNew( message )
-	return new( -tonumber( message ) )
-end
+local Proxy = {
+	_proxy = true,
+	__gc = function( s )
+		local data = objectData[ s ]
+		if data ~= nil then
+			data[ "alive" ] = false
+		end
+		local i = lookup[ s ]
+		if i ~= nil then
+			lookup[ s ] = nil
+			if i ~= 0 then
+				registry[ i ] = nil
+				print( "StyxScribeShared: Del: " .. tostring( i ) )
+			end
+		end
+		
+	end,
+	_new = function( m, ... )
+		local s = setmetatable( { }, m )
+		return (m._init or nop)( s, ... )
+	end,
+	_init = function( s, v, i )
+		local meta = getmetatable( s )
+		i = i or tonumber( ModUtil.ToString.Address( s ), 16 )
+		objectData[ s ] = { }
+		objectData[ s ][ "proxy" ] = meta:_newproxy( )
+		objectData[ s ][ "alive" ] = true
+		registry[ i ] = s
+		lookup[ s ] = i
+		objectData[ s ][ "root" ] = i == 0
+		objectData[ s ][ "local" ] = i > 0
+		if objectData[ s ][ "local" ] then
+			print( "StyxScribeShared: New: " .. meta._name .. delim .. i )
+		end
+		if v then
+			meta._marshall( s, v )
+		end
+		return s
+	end
+}
+
+local ProxySet = class( nil, Proxy, {
+	_shset = function( s, k, v )
+		local i = tostring( lookup[ s ] )
+		k = encode( k )
+		v = encode( v )
+		print( "StyxScribeShared: Set: " .. i .. delim .. k .. delim .. v )
+	end,
+	_marshall = function( s, obj )
+		for k, v in pairs( obj ) do
+			s[ k ] = v
+		end
+	end,
+	_newproxy = function( m )
+		return { }
+	end
+} )
+
+local ProxyCall = class( nil, Proxy, {
+	_marshall = function( s, f )
+		objectData[ s ][ "proxy" ] = f
+	end,
+	_newproxy = function( m )
+		return nop
+	end,
+} )
+
+local Table = marshallType( "table", class( "Table", ProxySet, {
+	__newindex = function( s, k, v, sync )
+		k, v = marshall( k ), marshall( v )
+		objectData[ s ][ "proxy" ][ k ] = v
+		local meta = getmetatable( s )
+		if sync == nil or sync then
+			meta._shset( s, k, v )
+		end
+	end,
+	__index = function( s, k )
+		return objectData[ s ][ "proxy" ][ k ]
+	end,
+	__len = function( s )
+		return #objectData[ s ][ "proxy" ]
+	end,
+	__next = function( s, ... )
+		return next( objectData[ s ][ "proxy" ], ... )
+	end,
+	__inext = function( s, ... )
+		return inext( objectData[ s ][ "proxy" ], ... )
+	end,
+	__pairs = function( s, ... )
+		return pairs( objectData[ s ][ "proxy" ], ... )
+	end,
+	__ipairs = function( s, ... )
+		return ipairs( objectData[ s ][ "proxy" ], ... )
+	end
+} ) )
+
+local Array = marshallType( "table", typeCall( class( "Array", ProxySet, {
+	__newindex = function( s, k, v, sync )
+		k, v = marshall( k ), marshall( v )
+		local proxy = objectData[ s ][ "proxy" ]
+		local n = #proxy
+		if type( k ) ~= "number" or math.floor( k ) ~= k then
+			error( "Array index must be an integer" , 2 )
+		end
+		if k > n + 1 or k < 1 then
+			error( "Array index " .. tostring( k ) .." out of bounds" , 2 )
+		end
+		proxy[ k ] = v
+		local meta = getmetatable( s )
+		if sync == nil or sync then
+			meta._shset( s, k - 1, v )
+		end
+	end,
+	__index = function( s, k )
+		return objectData[ s ][ "proxy" ][ k ]
+	end,
+	__len = function( s )
+		return #objectData[ s ][ "proxy" ]
+	end,
+	__next = function( s, ... )
+		return inext( objectData[ s ][ "proxy" ], ... )
+	end,
+	__inext = function( s, ... )
+		return inext( objectData[ s ][ "proxy" ], ... )
+	end,
+	__pairs = function( s, ... )
+		return ipairs( objectData[ s ][ "proxy" ], ... )
+	end,
+	__ipairs = function( s, ... )
+		return ipairs( objectData[ s ][ "proxy" ], ... )
+	end
+} ), function( cls, ... ) return cls:_new( ... ) end ) )
+
+local Args = marshallType( "table", typeCall( class( "Args", ProxySet, {
+	__newindex = function( s, k, v, sync )
+		k, v = marshall( k ), marshall( v )
+		local proxy = objectData[ s ][ "proxy" ]
+		local n = proxy.n or #proxy
+		if k == 'n' then
+			if v < n then
+				for i = v + 1, n, 1 do
+					proxy[ i ] = nil
+				end
+			end
+		else
+			if type( k ) ~= "number" or math.floor( k ) ~= k then
+				error( "Args index must be an integer" , 2 )
+			end
+			if k < 1 then
+				error( "Args index " .. tostring( k ) .." out of bounds" , 2 )
+			end
+			if k >= n then
+				proxy.n = k
+			end
+		end
+		proxy[ k ] = v
+		local meta = getmetatable( s )
+		if sync == nil or sync then
+			meta._shset( s, k ~= 'n' and k - 1 or k, v )
+		end
+	end,
+	__index = function( s, k )
+		return objectData[ s ][ "proxy" ][ k ]
+	end,
+	__len = function( s )
+		return objectData[ s ][ "proxy" ][ 'n' ]
+	end,
+	__next = function( s, ... )
+		return next( objectData[ s ][ "proxy" ], ... )
+	end,
+	__inext = function( s, ... )
+		local k, v = next( objectData[ s ][ "proxy" ], ... )
+		if k == 'n' then
+			k, v = next( objectData[ s ][ "proxy" ], k )
+		end
+		return k, v
+	end,
+	__pairs = function( s, ... )
+		return pairs( objectData[ s ][ "proxy" ], ... )
+	end,
+	__ipairs = function( s, ... )
+		return qrawipairs( objectData[ s ][ "proxy" ], ... )
+	end
+} ), function( cls, ... ) return cls:_new( ... ) end ) )
+
+local Action = marshallType( "function", typeCall( class( "Action", ProxyCall, {
+	_marshall = function( s, f )
+		objectData[ s ][ "proxy" ] = f
+	end,
+	__call = function( s, ... )
+		if objectData[ s ][ "local" ] then
+			objectData[ s ][ "proxy" ]( ... )
+		else
+            local i = tostring( lookup[ s ] )
+            local a = new( Args, table.pack( ... ) )
+            local ai = tostring( lookup[ a ] )
+            print("StyxScribeShared: Act: " .. i .. delim .. ai)
+		end
+	end
+} ), function( cls, ... ) return cls:_new( ... ) end ) )
 
 --https://stackoverflow.com/a/33312901
 local function split( text, delim )
@@ -74,6 +292,28 @@ local function split( text, delim )
     return result
 end
 
+local function marshaller( obj )
+	local t = type( obj )
+	local m = getmetatable( obj )
+    if m and m._proxy then return end
+    for _, m in ipairs( marshallTypesOrder ) do
+		for _, _t in pairs( marshallTypes[ m ] ) do
+			if t == _t then
+				return m
+			end
+		end
+	end
+end
+
+function marshall( obj )
+    local m = marshaller( obj )
+    if m then return new( m, obj ) end
+    if type( obj ) == "string" then
+        return obj:gsub( delim, ':' )
+	end
+    return obj
+end
+
 function decode( s )
 	local t, v = s:sub(1,1), s:sub(2)
 	if t == "&" then return v end
@@ -88,32 +328,72 @@ function encode( v )
 	local t, m = type( v ), getmetatable( v )
 	if t == "string" then return "&" .. v end
 	if t == "number" then return "#" .. tostring( v ) end
-	if m == meta then return "@" .. tostring( lookup[ v ] ) end
+	if m and m._proxy then return "@" .. tostring( lookup[ v ] ) end
 	if t == "boolean" then return v and "!!" or "!" end
 	if v == nil then return "*" end
 	error( tostring( v ) .. " cannot be encoded.", 2 )
 end
 
+local function handleNew( message )
+	if not ready then return end
+	local name, id = table.unpack( split( message, delim ) )
+	return new( classes[ name ], nil, -tonumber( id ) )
+end
+
+local function handleDel( message )
+	if not ready then return end
+	id = -tonumber( message )
+	obj = registry[ id ]
+	if obj ~= nil then
+		objectData[ obj ][ "alive" ] = false
+		registry[ id ] = nil
+	end
+end
+
 local function handleSet( message )
-	local id, key, value = table.unpack( split( message, '¦') )
-	id = -tonumber( id )
+	if not ready then return end
+	local id, key, value = table.unpack( split( message, delim ) )
+	local obj = registry[ -tonumber( id ) ]
 	key = decode( key )
 	value = decode( value )
-	objectData[ registry[ id ] ][ key ] = value
+	local meta = getmetatable( obj )
+	meta.__newindex( obj, key, value, false )
+end
+
+local function handleAct( message )
+	if not ready then return end
+	local func, args = table.unpack( split( message, delim ) )
+    func = registry[ -tonumber( func ) ]
+    args = registry[ -tonumber( args ) ]
+    func( table.unpack( objectData[ args ][ "proxy" ] ) )
 end
 
 local function handleReset( )
 	registry = { }
 	lookup = setmetatable( { }, { __mode = "k" } )
 	objectData = setmetatable( { }, { __mode = "k" } )
-	StyxScribe.Shared = new( 0 )
+	StyxScribeShared.Root = new( Table, nil, 0 )
+	ready = false
 	print( "StyxScribeShared: Reset" )
 end
 
+local function handleResetResponse( )
+	ready = true
+end
+
 StyxScribeShared.Internal = ModUtil.UpValues( function( )
-	return registry, lookup, objectData, getObjectData, handleNew, handleSet, handleReset, decode, encode
+	return registry, lookup, delim, objectData, split, class, new, nop,
+		marshallType, marshallTypes, marshaller, marshall, _table, _function,
+		Proxy, ProxySet, ProxyCall, typeCall, decode, encode, ready,
+		handleNew, handleSet, handleReset,
+		Table, Array, Args, Action
 end )
 
-handleReset( )
+StyxScribeShared.Table, StyxScribeShared.Array, StyxScribeShared.Args, StyxScribeShared.Action = Table, Array, Args, Action
+
+StyxScribe.AddHook( handleResetResponse, "StyxScribeShared: Reset", StyxScribeShared )
 StyxScribe.AddHook( handleNew, "StyxScribeShared: New: ", StyxScribeShared )
 StyxScribe.AddHook( handleSet, "StyxScribeShared: Set: ", StyxScribeShared )
+StyxScribe.AddHook( handleDel, "StyxScribeShared: Del: ", StyxScribeShared )
+StyxScribe.AddHook( handleAct, "StyxScribeShared: Act: ", StyxScribeShared )
+handleReset( )

--- a/Content/Mods/StyxScribeShared/StyxScribeShared.py
+++ b/Content/Mods/StyxScribeShared/StyxScribeShared.py
@@ -1,103 +1,433 @@
 from weakref import WeakKeyDictionary
 from numbers import Number
+from collections import OrderedDict
+from inspect import getmembers
+from functools import wraps
+from threading import local as thread_local
+from types import MethodType
+
+proxy_types = dict()
+marshall_types = OrderedDict()
+DELIM = '¦'
+NIL = None
 
 registry = None
 lookup = None
+Root = None
 
-def not_implemented(*args, **kwargs):
-    raise NotImplementedError("Cannot used shared object this way.")
+#https://stackoverflow.com/a/49013535
+_meta_ignore = {"__repr__","__format__","__str__","__reduce__","__reduce_ex__","__sizeof__"}
+_meta_inherited = {}
+def _meta_wrap(name, method):
+    local_flag = thread_local()
+    @wraps(method)
+    def wrapper(*args, **kw):
+        local_method = method
+        if not getattr(local_flag, "running", False) and args and not isinstance(args[0], type):
+            local_flag.running = True
+            # trigger __getattribute__:
+            self = args[0]
+            cls = self.__class__
+            retrieved = cls.__getattribute__(self, name)
+            if not retrieved is wrapper:
+                local_method =  retrieved
+            if isinstance(local_method, MethodType):
+                args = args[1:]
+        result = local_method(*args, **kw)
+        local_flag.running = False
+        return result
+    wrapper._wrapped = True
+    return wrapper
+class MetaOverrider(type):
+    def __init__(cls, name, bases, namespace, **kwd):
+        super().__init__(name, bases, namespace, **kwd)
+        
+        global _meta_inherited
+        d = None
+        for c in cls.__mro__:
+            if "Proxy" not in map(lambda _c: _c.__name__, c.__mro__):
+                _cls = c
+                d = inherited(_cls, cls)
+                break
+        _meta_inherited[cls] = d
 
-class Shared(dict):
-    def __call__(self):
-        return __class__()
-    def __hash__(self):
-        return hash(id(self))
-    def __init__(self, i=None):
+        for name in dir(cls):
+            if not (name.startswith("__") and name.endswith("__")):
+                continue
+            if name in ("__getattribute__", "__class__", "__init__"):
+                continue
+            if name in object.__dict__ and name not in _meta_ignore:
+                continue
+            if d is not None and name not in d:
+                continue
+            magic_method = getattr(cls, name)
+            if not callable(magic_method) or getattr(magic_method, "_wrapped", False):
+                continue
+            setattr(cls, name, _meta_wrap(name, magic_method))
+
+def nop():
+    pass
+
+def inherited(a,b):
+    #https://stackoverflow.com/a/48281090
+    a = dict(getmembers(a))
+    b = dict(getmembers(b))
+    return {k:v for k,v in b.items() if k in a and v == a[k]}
+
+class _function():
+    def __init__(self,call=None):
+        if call is None:
+            call = nop
+        self.call = call
+    def __call__(self,*args,**kwargs):
+        return self.call(*args,**kwargs)
+    def __repr__(self):
+        return repr(self.call)
+
+def not_implemented(self, *args, **kwargs):
+    raise NotImplementedError(f"{type(self)} does not implement this operation")
+
+def proxytype(cls):
+    proxy_types[cls.__name__] = cls
+    return cls
+
+def marshalltype(*types):
+    def f(cls):
+        for t in types:
+            mt = marshall_types.get(cls,set())
+            mt.add(t)
+            marshall_types[cls] = mt
+        return cls
+    return f
+
+class Proxy(metaclass=MetaOverrider):
+    def __init__(self, v=None, i=None):
+        #initialise a new object to proxy, select from inheritance
+        for cls in type(self).__mro__:
+            if Proxy not in cls.__mro__:
+                proxy = cls()
+                break
         if i is None:
             i = id(self)
+        self.proxy = proxy
+        self.alive = True
         registry[i] = self
         lookup[self] = i
-        if i > 0:
-            scribe.send("StyxScribeShared: New: " + str(i))
-    def __setitem__(self, key, val):
-        if val is None:
-            return self.__delitem__(key)
-        if isinstance(val, int):
-            val = float(val)
-        i = str(lookup[self])
-        k = encode(key)
-        v = encode(val)
-        super(__class__, self).__setitem__(key, val)
-        scribe.send("StyxScribeShared: Set: " + i + '¦' + k + '¦' + v)
+        self.root = i == 0
+        self.local = i > 0
+        if self.local:
+            scribe.send(f"StyxScribeShared: New: {self.__class__.__name__}{DELIM}{i}")
+        if v is not None:
+            self._marshall(v)
+    def __hash__(self):
+        return hash(id(self))
+    def __repr__(self):
+        return repr(self.proxy)
+    def __del__(self):
+        i = lookup.get(self,None)
+        if i is not None:
+            self.alive = False
+            try:
+                del lookup[self]
+            except KeyError:
+                pass
+            if i != 0:
+                try:
+                    del registry[i]
+                except KeyError:
+                    pass
+                if self.local:
+                    scribe.send(f"StyxScribeShared: Del: {i}")
+    def __getattribute__(self, name):
+        if name in _meta_inherited[type(self)]:
+            proxy = object.__getattribute__(self, "proxy")
+            try:
+                attr = getattr(proxy, name)
+                if callable(attr) and attr.__self__ == proxy:
+                    return lambda s,*a,**k: attr(*a,**k)
+                return attr
+            except AttributeError:
+                pass
+        return object.__getattribute__(self, name)       
+
+class ProxySet(Proxy):
+    def _shset(self, key, val):
+        if self.alive:
+            i = lookup[self]
+            k = encode(key)
+            v = encode(val)
+            scribe.send(f"StyxScribeShared: Set: {i}{DELIM}{k}{DELIM}{v}")
+
+class ProxyCall(Proxy):
+    def _marshall(self, obj):
+        if callable(obj):
+            self.proxy = obj
+        else:
+            raise TypeError(f"{type(self)} cannot marshall type {type(obj)}")
+
+@proxytype
+@marshalltype(dict, set)
+class Table(ProxySet, dict):
+    def _marshall(self, obj):
+        if isinstance(obj, set):
+            for k in obj:
+                self[k] = True
+        elif isinstance(obj, dict):
+            for k,v in obj.items():
+                self[k] = v
+        raise TypeError(f"{type(self)} cannot marshall type {type(obj)}")
+    def __setitem__(self, key, val, sync=True):
+        if val is NIL:
+            return self.__delitem__(key, sync)
+        val = marshall(val)
+        key = marshall(key)
+        self.proxy[key] = val
+        
+        if sync:
+            self._shset(key, val)
     def __delitem__(self, key):
-        i = str(lookup[self])
-        k = encode(key)
-        v = encode(None)
-        super(__class__, self).__delitem__(key)
-        scribe.send("StyxScribeShared: Set: " + i + '¦' + k + '¦' + v)
+        del self.proxy[key]
+        key = marshall(key)
+        if sync:
+            self._shset(key, val)
     def __getitem__(self, key):
         try:
-            return super(__class__, self).__getitem__(key)
+            return self.proxy[key]
         except KeyError:
-            return None
+            return NIL
     setdefault = not_implemented
     update = not_implemented
     pop = not_implemented
     popitem = not_implemented
     clear = not_implemented
-    
+
+@proxytype
+@marshalltype(list, tuple)
+class Array(ProxySet, list):
+    def _marshall(self, obj):
+        enum = None
+        try:
+            enum = enumerate(obj)
+        except TypeError:
+            raise TypeError(f"{type(self)} cannot marshall type {type(obj)}")
+        for k,v in enum:
+            self[k] = v
+    def __setitem__(self, key, val, sync=True):
+        if val is NIL:
+            return self.__delitem__(key, sync)
+
+        key = marshall(key)
+        if key > len(self.proxy):
+            return
+        val = marshall(val)
+        if key == len(self.proxy):
+            self.proxy.append(val)
+        else:
+            self.proxy[key] = val
+        if sync:
+            self._shset(key + 1, val)
+    def __delitem__(self, key, sync=True):
+        d = key - len(self.proxy) + 1
+        if d < 0:
+            for i in range(d):
+                del self.proxy[-1]
+        del self.proxy[key]
+        key = int(marshall(key))
+        if sync:
+            self._shset(key, NIL)
+    def __getitem__(self, key):
+        try:
+            return self.proxy[key]
+        except KeyError:
+            return NIL
+    append = not_implemented
+    extend = not_implemented
+    insert = not_implemented
+    remove = not_implemented
+    sort = not_implemented
+    reverse = not_implemented
+    pop = not_implemented
+    clear = not_implemented
+
+@proxytype
+@marshalltype(list, tuple)
+class Args(ProxySet, list):
+    def _marshall(self, obj):
+        enum = None
+        try:
+            enum = enumerate(obj)
+        except TypeError:
+            raise TypeError(f"{cls} cannot marshall type {type(obj)}")
+        for k,v in enum:
+            self[k] = v
+    def __setitem__(self, key, val, sync=True):
+        if val is NIL:
+            return self.__delitem__(key, sync)
+
+        n = len(self.proxy)
+        if key == 'n':
+            val = marshall(val)
+            if val >= n:
+                self.proxy.extend([NIL]*(val - n))
+            if val < n:
+                self.proxy[::] = self.proxy[:val]
+        else:
+            key = marshall(key)
+            val = marshall(val)
+            if key > n:
+                self.proxy.extend([NIL]*(key - n)+[val])
+            if key == len(self.proxy):
+                self.proxy.append(val)
+            else:   
+                self.proxy[key] = val
+        if sync:
+            self._shset(key if key == 'n' else key + 1, val)
+    def __delitem__(self, key, sync=True):
+        key = marshall(key)
+        if key >= len(self.proxy):
+            return
+        self.proxy[key] = NIL
+        if sync:
+            self._shset(key, NIL)
+    def __getitem__(self, key):
+        if key == 'n':
+            return len(self.proxy)
+        try:
+            return self.proxy[key]
+        except KeyError:
+            return NIL
+    append = not_implemented
+    extend = not_implemented
+    insert = not_implemented
+    remove = not_implemented
+    sort = not_implemented
+    reverse = not_implemented
+    pop = not_implemented
+    clear = not_implemented
+
+@proxytype
+@marshalltype(_function)
+class Action(ProxyCall, _function):
+    def __call__(self, *args):
+        if self.local:
+            self.proxy(*args)
+        else:
+            i = lookup[self]
+            a = Args(args)
+            ai = lookup[a]
+            scribe.send(f"StyxScribeShared: Act: {i}{DELIM}{ai}")
+
+def marshaller(obj):
+    if isinstance(obj,Proxy):
+        return None
+    for c,ts in marshall_types.items():
+        for t in ts:
+            if isinstance(obj,t):
+                return c
+            if callable(obj) and t is _function:
+                return c
+    return None
+
+def marshall(obj):
+    m = marshaller(obj)
+    if m is not None:
+        return m(obj)
+    if isinstance(obj,str):
+        return obj.replace(DELIM,':')
+    if isinstance(obj,float):
+        if float.is_integer(obj):
+            return int(obj)
+    return obj
+
+def encode(v):
+    if isinstance(v, bool):
+        return "!!" if v else "!"
+    if isinstance(v, str):
+        return "&" + v
+    if isinstance(v, Number):
+        return "#" + str(v)
+    if isinstance(v, Proxy):
+        return "@" + str(lookup[v])
+    if v is NIL:
+        return "*"
+    raise TypeError(f"{v} of type {type(v)} cannot be encoded.")
+
 def decode(s):
     t = s[:1]
     v = s[1:]
     if t == "&":
         return v
     if t == "#":
+        if v.isdigit():
+            return int(v)
         return float(v)
     if t == "@":
         return registry[-int(v)]
     if t == "!":
-        return v == "!"
+        return v[0] == '!'
     if t == "*":
-        return None
+        return NIL
     raise TypeError(s + " cannot be decoded.")
 
-
-def encode(v):
-    if isinstance(v, str):
-        return "&" + v
-    if isinstance(v, Number):
-        return "#" + str(v)
-    if isinstance(v, Shared):
-        return "@" + str(lookup[v])
-    if isinstance(v, bool):
-        return "!!" if v else "!"
-    if v is None:
-        return "*"
-    raise TypeError(v + " cannot be encoded.")
-
 def handle_new(message):
-    return Shared(-int(message))
+    t, i = message.split(DELIM)
+    val = proxy_types[t](None, -int(i))
+    return val
 
 def handle_set(message):
-    i, k, v = message.split('¦')
+    i, k, v = message.split(DELIM)
+    try:
+        s = registry[-int(i)]
+    except KeyError:
+        return
     k = decode(k)
+    if v[:1] == '&':
+        v = v[:-1]
     v = decode(v)
-    s = super(Shared, registry[-int(i)])
-    if v is None:
-        s.__delitem__(k)
-    else:
-        s.__setitem__(k, v)
+    s.__setitem__(k, v, False)
 
-def handle_reset(message):
+def handle_del(message):
+    i = -int(message)
+    obj = registry.get(i,None)
+    if obj is not None:
+        obj.alive = False
+        try:
+            del lookup[obj]
+        except KeyError:
+            pass
+        if i != 0:
+            try:
+                del registry[i]
+            except KeyError:
+                pass
+
+def handle_act(message):
+    func, args = message.split(DELIM)
+    func = registry[-int(func)]
+    args = registry[-int(args)]
+    func(*args)
+
+def handle_reset(message=None):
     global registry
     global lookup
     global obj_data
+    global Root
+    if registry is not None:
+        registry.clear()
     registry = {}
+    if lookup is not None:
+        lookup.clear()
     lookup = WeakKeyDictionary()
-    scribe.shared = Shared(0)
+    Root = Table(None, 0)
+    scribe.send( "StyxScribeShared: Reset" )
 
 def load():
     scribe.add_hook(handle_reset, "StyxScribeShared: Reset", __name__)
     scribe.add_hook(handle_new, "StyxScribeShared: New: ", __name__)
     scribe.add_hook(handle_set, "StyxScribeShared: Set: ", __name__)
+    scribe.add_hook(handle_del, "StyxScribeShared: Del: ", __name__)
+    scribe.add_hook(handle_act, "StyxScribeShared: Act: ", __name__)
     scribe.ignore_prefixes.append("StyxScribeShared:")
+
+def run():
+    handle_reset()


### PR DESCRIPTION
- Shared is now Root
- doesn't infect scribe's namespace
- python lists, tuples -> Array
- python dicts, sets -> Table <- lua table
- special args type
- None returning python functions -> Action <- nil returning lua functions