### PR TITLE
Capitalisation updates in accordance with new naming conventions

### DIFF
--- a/Content/Mods/StyxScribeREPL/StyxScribeREPL.py
+++ b/Content/Mods/StyxScribeREPL/StyxScribeREPL.py
@@ -64,9 +64,9 @@ class KeyboardThread(threading.Thread):
             while True:
                 self.input_cbk(input()) #waits to get input + Return
         except EOFError:
-            end()
+            End()
         except KeyboardInterrupt:
-            end()
+            End()
 
 def evaluate(inp):
     #evaluate the keyboard input

--- a/SubsumeHades.py
+++ b/SubsumeHades.py
@@ -1,4 +1,4 @@
-from styxscribe import StyxScribe
+from StyxScribe import StyxScribe
 
 import sys, os
 from pathlib import Path

--- a/SubsumePyre.py
+++ b/SubsumePyre.py
@@ -1,4 +1,4 @@
-from styxscribe import StyxScribe
+from StyxScribe import StyxScribe
 
 import sys, os
 from pathlib import Path


### PR DESCRIPTION
Fixes launching via the Subsume* scripts and being able to exit script with Ctrl+C